### PR TITLE
add read buffer on blobnode wrapper

### DIFF
--- a/pye57/libe57_wrapper.cpp
+++ b/pye57/libe57_wrapper.cpp
@@ -448,6 +448,13 @@ PYBIND11_MODULE(libe57, m) {
     cls_BlobNode.def("__repr__", [](const BlobNode &node) {
         return "<BlobNode '" + node.elementName() + "'>";
     });
+    cls_BlobNode.def("read_buffer", [](const BlobNode &node) -> py::array {
+        BlobNode copyNode = node;
+        int64_t bufferSizeExpected = copyNode.byteCount();
+        uint8_t *pBuffer = new uint8_t[bufferSizeExpected];
+        copyNode.read(pBuffer, 0, bufferSizeExpected);
+        return py::array(bufferSizeExpected, pBuffer);
+    });
 
     py::class_<ImageFile> cls_ImageFile(m, "ImageFile");
     cls_ImageFile.def(py::init<const std::string &, const std::string &, int>(), "fname"_a, "mode"_a, "checksumPolicy"_a=CHECKSUM_POLICY_ALL);

--- a/pye57/libe57_wrapper.cpp
+++ b/pye57/libe57_wrapper.cpp
@@ -448,12 +448,11 @@ PYBIND11_MODULE(libe57, m) {
     cls_BlobNode.def("__repr__", [](const BlobNode &node) {
         return "<BlobNode '" + node.elementName() + "'>";
     });
-    cls_BlobNode.def("read_buffer", [](const BlobNode &node) -> py::array {
-        BlobNode copyNode = node;
-        int64_t bufferSizeExpected = copyNode.byteCount();
-        uint8_t *pBuffer = new uint8_t[bufferSizeExpected];
-        copyNode.read(pBuffer, 0, bufferSizeExpected);
-        return py::array(bufferSizeExpected, pBuffer);
+    cls_BlobNode.def("read_buffer", [](BlobNode &node) -> py::array {
+        int64_t bufferSizeExpected = node.byteCount();
+        py::array_t<uint8_t> arr(bufferSizeExpected);
+        node.read(arr.mutable_data(), 0, bufferSizeExpected);
+        return arr;
     });
 
     py::class_<ImageFile> cls_ImageFile(m, "ImageFile");


### PR DESCRIPTION
# Description
Add a read_buffer method to BlobNode wrapper

You can use this method to read jpegImage buffer and save cubemap data from .e57 file

# Example
```
e57 = pye57.E57("test.e57")
jpeg_buffer = e57.root["images2D"][0]["pinholeRepresentation"]["jpegImage"].read_buffer()
with open("out_0.jpg", "wb") as _f:
        _f.write(jpeg_buffer)
```