### PR TITLE
Allow passing buffers to BlobNode read and write.

### DIFF
--- a/pye57/libe57_wrapper.cpp
+++ b/pye57/libe57_wrapper.cpp
@@ -435,8 +435,40 @@ PYBIND11_MODULE(libe57, m) {
     py::class_<BlobNode> cls_BlobNode(m, "BlobNode");
     cls_BlobNode.def(py::init<e57::ImageFile, int64_t>(), "destImageFile"_a, "byteCount"_a);
     cls_BlobNode.def("byteCount", &BlobNode::byteCount);
-    cls_BlobNode.def("read", &BlobNode::read, "buf"_a, "start"_a, "byteCount"_a);
-    cls_BlobNode.def("write", &BlobNode::write, "buf"_a, "start"_a, "byteCount"_a);
+    cls_BlobNode.def("read", [](BlobNode& node, py::buffer buf, int64_t start, size_t count) {
+        py::buffer_info info = buf.request();
+
+        if (info.ndim != 1) {
+            throw std::runtime_error("Incompatible buffer dimension!");
+        }
+
+        if (info.format != "B") {
+            throw std::runtime_error("Incompatible buffer type!");
+        }
+
+        if (static_cast<size_t>(info.shape[0]) < count) {
+            throw std::runtime_error("Buffer not large enough to read.");
+        }
+
+        node.read(reinterpret_cast<uint8_t*>(info.ptr), start, count);
+    });
+    cls_BlobNode.def("write", [](BlobNode& node, py::buffer buf, int64_t start, size_t count) {
+        py::buffer_info info = buf.request();
+
+        if (info.ndim != 1) {
+            throw std::runtime_error("Incompatible buffer dimension!");
+        }
+
+        if (info.format != "B") {
+            throw std::runtime_error("Incompatible buffer type!");
+        }
+
+        if (static_cast<size_t>(info.shape[0]) < count) {
+            throw std::runtime_error("Buffer not large enough to write.");
+        }
+
+        node.write(reinterpret_cast<uint8_t*>(info.ptr), start, count);
+    });
     cls_BlobNode.def(py::init<const e57::Node &>(), "n"_a);
     cls_BlobNode.def("isRoot", &BlobNode::isRoot);
     cls_BlobNode.def("parent", &BlobNode::parent);


### PR DESCRIPTION
For example:

```
jpeg_image_data = np.zeros(shape=jpeg_image.byteCount(), dtype=np.uint8)
jpeg_image.read(jpeg_image_data, 0, jpeg_image.byteCount());
image = cv.imdecode(jpeg_image_data, cv.IMREAD_COLOR)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidcaron/pye57/13)
<!-- Reviewable:end -->
