### PR TITLE
fix-identity quaternion

### DIFF
--- a/src/pye57/e57.py
+++ b/src/pye57/e57.py
@@ -194,7 +194,7 @@ class E57:
                 raise ValueError("Unsupported point field: %s" % field)
 
         if rotation is None:
-            rotation = getattr(scan_header, "rotation", np.array([0, 0, 0, 1]))
+            rotation = getattr(scan_header, "rotation", np.array([1, 0, 0, 0]))
 
         if translation is None:
             translation = getattr(scan_header, "translation", np.array([0, 0, 0]))

--- a/src/pye57/e57.py
+++ b/src/pye57/e57.py
@@ -194,7 +194,7 @@ class E57:
                 raise ValueError("Unsupported point field: %s" % field)
 
         if rotation is None:
-            rotation = getattr(scan_header, "rotation", np.array([0, 0, 0, 0]))
+            rotation = getattr(scan_header, "rotation", np.array([0, 0, 0, 1]))
 
         if translation is None:
             translation = getattr(scan_header, "translation", np.array([0, 0, 0]))


### PR DESCRIPTION
Write produces an invalid bbox when no rotation is set.
This is due to incorrect identify quaternion making the bounding box all zero's.
The no rotation identify should be 1,0,0,0

http://kieranwynn.github.io/pyquaternion/#object-initialisation