### PR TITLE
fix issue when rotation is not provided in pose

### DIFF
--- a/src/pye57/scan_header.py
+++ b/src/pye57/scan_header.py
@@ -24,15 +24,15 @@ class ScanHeader:
 
     @property
     def rotation_matrix(self) -> np.array:
-        
         q = Quaternion([e.value() for e in self.node["pose"]["rotation"]])
         return q.rotation_matrix
 
     @property
     def rotation(self) -> np.array:
         try:
-            q = Quaternion([e.value() for e in self.node["pose"]["rotation"]])
-        except libe57.E57Exception:
+            rotation = self.node["pose"]["rotation"]
+            q = Quaternion([e.value() for e in rotation])
+        except KeyError:
             q = Quaternion()
         return q.elements
 

--- a/src/pye57/scan_header.py
+++ b/src/pye57/scan_header.py
@@ -24,12 +24,16 @@ class ScanHeader:
 
     @property
     def rotation_matrix(self) -> np.array:
+        
         q = Quaternion([e.value() for e in self.node["pose"]["rotation"]])
         return q.rotation_matrix
 
     @property
     def rotation(self) -> np.array:
-        q = Quaternion([e.value() for e in self.node["pose"]["rotation"]])
+        try:
+            q = Quaternion([e.value() for e in self.node["pose"]["rotation"]])
+        except libe57.E57Exception:
+            q = Quaternion()
         return q.elements
 
     @property

--- a/src/pye57/scan_header.py
+++ b/src/pye57/scan_header.py
@@ -5,6 +5,10 @@ from pye57 import libe57
 from pye57.utils import get_fields, get_node
 
 class ScanHeader:
+    """Provides summary statistics for an individual lidar scan in an E57 file.
+
+    Including the number of points, bounds and pose of the scan.
+    """
     def __init__(self, scan_node):
         self.node = scan_node
         points = self.node["points"]


### PR DESCRIPTION
When rotation is not provided in the node `pose` data, it raises a `E57Exception` exception. I propose to catch it and to instantiate the default quaternion in that case.