### PR TITLE
Add allowParallel option

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libE57Format"]
 	path = libE57Format
-	url = https://github.com/asmaloney/libE57Format
+	url = https://github.com/nh2/libE57Format.git

--- a/src/pye57/libe57_wrapper.cpp
+++ b/src/pye57/libe57_wrapper.cpp
@@ -348,7 +348,7 @@ PYBIND11_MODULE(libe57, m) {
     cls_CompressedVectorNode.def("prototype", &CompressedVectorNode::prototype);
     cls_CompressedVectorNode.def("codecs", &CompressedVectorNode::codecs);
     cls_CompressedVectorNode.def("writer", &CompressedVectorNode::writer, "sbufs"_a);
-    cls_CompressedVectorNode.def("reader", &CompressedVectorNode::reader, "dbufs"_a);
+    cls_CompressedVectorNode.def("reader", &CompressedVectorNode::reader, "dbufs"_a, "allowParallel"_a=false);
     cls_CompressedVectorNode.def(py::init<const e57::Node &>(), "n"_a);
     cls_CompressedVectorNode.def("isRoot", &CompressedVectorNode::isRoot);
     cls_CompressedVectorNode.def("parent", &CompressedVectorNode::parent);


### PR DESCRIPTION
Draft PR for in-review `libE57Format` feature to allow parallel read access to the same E57 handle, e.g. with Python's `ThreadPoolExecutor`: https://github.com/asmaloney/libE57Format/pull/292

## TODO

* [ ] Once https://github.com/asmaloney/libE57Format/pull/292 is merged, remove the submodule change