### PR TITLE
feat: add macos support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          brew install xerces-c
+          "bash scripts/install_xerces_c.sh"
 
       - name: Install package
         run: pip install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          "bash scripts/install_xerces_c.sh"
+          bash ../scripts/install_xerces_c.sh
 
       - name: Install package
         run: pip install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,8 +94,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install build dependencies
+        working-directory: ./scripts
         run: |
-          bash ../scripts/install_xerces_c.sh
+          bash install_xerces_c.sh
 
       - name: Install package
         run: pip install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: build
 on: [push, pull_request]
 
 jobs:
+
   build-and-test-ubuntu:
     name: Ubuntu (python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -75,16 +76,47 @@ jobs:
         shell: pwsh
         run: python -m pytest tests
 
+  build-and-test-macos:
+    name: macOS (python ${{ matrix.python-version }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build dependencies
+        run: |
+          brew install xerces-c
+
+      - name: Install package
+        run: pip install .
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run tests
+        run: python -m pytest tests
+
   build_wheels:
     name: Build wheels
     runs-on: ${{ matrix.os }}
     needs:
       - build-and-test-ubuntu
       - build-and-test-windows
+      - build-and-test-macos
     if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-2019"]
+        os: ["ubuntu-latest", "windows-2019", "macos-latest"]
 
     steps:
       - uses: actions/checkout@v2
@@ -108,6 +140,13 @@ jobs:
         env:
           CIBW_BEFORE_ALL_WINDOWS: "powershell scripts/install_xerces_c.ps1"
 
+      - name: Build wheels (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          python -m cibuildwheel --platform macos --output-dir wheelhouse
+        env:
+          CIBW_BEFORE_ALL_LINUX: "bash scripts/install_xerces_c.sh"
+
       - uses: actions/upload-artifact@v2
         with:
           name: wheels-${{ matrix.os }}
@@ -120,6 +159,7 @@ jobs:
     needs:
       - build-and-test-ubuntu
       - build-and-test-windows
+      - build-and-test-macos
     steps:
       - uses: actions/checkout@v2
         with:
@@ -141,12 +181,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: wheels-ubuntu-latest
-          path: dist
-
-      - uses: actions/download-artifact@v2
-        with:
-          name: wheels-windows-2019
+          name: wheels-macos-latest
           path: dist
 
       - uses: actions/download-artifact@v2

--- a/README.md
+++ b/README.md
@@ -68,21 +68,21 @@ translation_x = scan_0["pose"]["translation"]["x"]
 
 ## Installation
 
-If you're on linux or Windows, a wheel should be available.
+On linux Windows or macos:
 
 `python -m pip install pye57`
 
-## Building from source
+## Building from source (for developers)
 
-### Cloning the repository and required submodules
+### Cloning the repository with required submodule
 
-Clone a new repository along with the required submodules
+Clone a new repository along with the libe57Format submodule
 
 `git clone https://github.com/davidcaron/pye57.git --recursive`
 
 If the repository has already been previously cloned, but without the --recursive flag
 
-```
+```Bash
 cd pye57 # go to the cloned repository
 git submodule init # this will initialise the submodules in the repository
 git submodule update # this will update the submodules in the repository
@@ -102,7 +102,7 @@ To get xerces-c, you can either build from source or if you're using conda:
 
 ### Run `pip install` from the repo source
 
-```
+```Bash
 cd pye57
 python -m pip install .
 ```
@@ -111,6 +111,6 @@ python -m pip install .
 
 Use pip again
 
-```
+```Bash
 python -m pip uninstall pye57
 ```

--- a/scripts/install_xerces_c.sh
+++ b/scripts/install_xerces_c.sh
@@ -7,25 +7,32 @@ XERCES_MINOR=2
 XERCES_PATCH=3
 
 XERCES_VERSION=${XERCES_MAJOR}.${XERCES_MINOR}.${XERCES_PATCH}
-XSD_BUILD_AREA=/tmp/build_xerces_c
-
-echo "Create Xerces-C build area..."
-mkdir -p ${XSD_BUILD_AREA}
-cd ${XSD_BUILD_AREA}
 
 echo "Download Xerces-C..."
 curl -L https://github.com/apache/xerces-c/archive/v${XERCES_VERSION}.tar.gz --output xerces-c-${XERCES_VERSION}.tar.gz
 echo "Extract Xerces-C..."
 tar xzf xerces-c-${XERCES_VERSION}.tar.gz
-cd  xerces-c-${XERCES_VERSION}
-echo "Configure Xerces-C..."
-./reconf
-./configure
+cd xerces-c-${XERCES_VERSION}
+
+# Check the operating system and install dependencies accordingly
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Installing dependencies on macOS..."
+    brew install autoconf automake libtool
+else
+    echo "Installing dependencies on Linux..."
+    sudo apt-get install -y autoconf automake libtool
+fi
+
+echo "Generate configure script using autoreconf..."
+autoreconf -i
+
+echo "Configure Xerces-C for macOS..."
+./configure --prefix=/usr/local --enable-static
+
 echo "Build Xerces-C..."
 make
-echo "Install Xerces-C..."
-make install
 
-echo "Clean up Xerces-C..."
-cd /
-rm -rf ${XSD_BUILD_AREA}
+echo "Install Xerces-C..."
+sudo make install
+
+echo "Xerces-C installed successfully."

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,15 @@ if platform.system() == "Windows":
         # include xerces-c dll in the package
         shutil.copy2(xerces_dir / "bin" / "xerces-c_3_2.dll", HERE / "src" / "pye57")
         package_data.append("xerces-c_3_2.dll")
-
+elif platform.system() == "Darwin":
+    xerces_dir = Path("/usr/local/")
+    if xerces_dir.exists():
+        # include xerces-c dylib in the package
+        shutil.copy2(xerces_dir / "lib" / "libxerces-c-3.2.dylib", HERE / "src" / "pye57")
+        library_dirs.append(str(xerces_dir / "lib"))
+        include_dirs.append(str(xerces_dir / "include"))
+        package_data.append("libxerces-c.a")
+    libraries.append("xerces-c")
 else:
     libraries.append("xerces-c")
 
@@ -56,6 +64,9 @@ ext_modules = [
         libraries=libraries,
         library_dirs=library_dirs,
         language="c++",
+        extra_link_args=[
+            f"-Wl,-rpath,@loader_path",
+        ],
     ),
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
pye57 library does not support macOS builds at the moment.

### What was the solution? (How)
Updated xerces-c installation as a static dependency which is now referenced by the libe57 binary.

### How was this change tested?
`sh scripts/install_xerces_c.sh`
`python3 setup.py bdist_wheel`

This execution now is able to build a macOS wheel.

Ran:
`pip install dist/{wheel}`
`import pye57` executes without an error.