### PR TITLE
fix: macOS ci build wheels env variable update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
         run: |
           python -m cibuildwheel --platform macos --output-dir wheelhouse
         env:
-          CIBW_BEFORE_ALL_LINUX: "bash scripts/install_xerces_c.sh"
+          CIBW_BEFORE_ALL_MACOS: "bash scripts/install_xerces_c.sh"
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Building macOS wheels was using the wrong CIBW variable. Variable to be used is `CIBW_BEFORE_ALL_MACOS` instead of `CIBW_BEFORE_ALL_LINUX`. 

https://cibuildwheel.pypa.io/en/stable/options/#before-all

