### PR TITLE
Python3.13 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install cibuildwheel
         run: |
@@ -139,7 +139,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_LINUX: "bash scripts/install_xerces_c.sh"
           CIBW_BUILD: "cp*-manylinux_x86_64"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8, <3.13"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8, <3.14"
 
       - name: Build wheels (Windows)
         if: matrix.os == 'windows-2019'
@@ -148,7 +148,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_WINDOWS: "powershell scripts/install_xerces_c.ps1"
           CIBW_BUILD: "cp*-win_amd64*"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8, <3.13"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8, <3.14"
 
       - name: Build wheels (macOS)
         if: matrix.os == 'macos-latest'
@@ -157,7 +157,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL_MACOS: "bash scripts/install_xerces_c.sh"
           CIBW_BUILD: "cp*-macosx*"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8, <3.13"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8, <3.14"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -191,7 +191,7 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "windows-2019", "macos-latest" ]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install build dependencies
         run: |
@@ -91,6 +92,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install build dependencies
         working-directory: ./scripts
@@ -126,6 +128,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          allow-prereleases: true
 
       - name: Install cibuildwheel
         run: |
@@ -201,6 +204,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           activate-environment: pye57
-          channels: conda-forge
+          channels: conda-forge,conda-forge/label/python_rc
           miniconda-version: "latest"
 
       - name: Install Dependencies

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     cmdclass={"build_ext": BuildExt},


### PR DESCRIPTION
This pull request makes several updates to the `.github/workflows/build.yml` file to support Python 3.13 and allow pre-release versions. Additionally, it updates `setup.py` to include Python 3.13 in the list of supported versions.

### Workflow Updates:
* Added Python 3.13 to the `python-version` matrix for Ubuntu, Windows, and macOS builds in `.github/workflows/build.yml`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-R11) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L42-R43) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L83-R84) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L194-R197)
* Enabled `allow-prereleases` for Python setup in `.github/workflows/build.yml`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R22) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R95) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L128-R131) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R207)
* Updated `CIBW_PROJECT_REQUIRES_PYTHON` to `>=3.8, <3.14` in `.github/workflows/build.yml`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L142-R145) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L151-R154) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L160-R163)
* Added `conda-forge/label/python_rc` channel to conda setup in `.github/workflows/build.yml`.

### Setup.py Update:
* Added Python 3.13 to the list of supported versions in `setup.py`.