### PR TITLE
Added fix and test for write_scan_raw with omited low values for rowIndex or columnIndex

### DIFF
--- a/src/pye57/e57.py
+++ b/src/pye57/e57.py
@@ -376,9 +376,9 @@ class E57:
             max_row = np.max(data["rowIndex"])
             min_col = np.min(data["columnIndex"])
             max_col = np.max(data["columnIndex"])
-            points_prototype.set("rowIndex", libe57.IntegerNode(self.image_file, 0, min_row, max_row))
+            points_prototype.set("rowIndex", libe57.IntegerNode(self.image_file, min_row, min_row, max_row))
             field_names.append("rowIndex")
-            points_prototype.set("columnIndex", libe57.IntegerNode(self.image_file, 0, min_col, max_col))
+            points_prototype.set("columnIndex", libe57.IntegerNode(self.image_file, min_col, min_col, max_col))
             field_names.append("columnIndex")
 
         if "cartesianInvalidState" in data:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -419,3 +419,27 @@ def test_clone_e57(e57_with_data_and_images_path, temp_e57_write):
 
     in_image.close()
     out_image.close()
+
+
+def test_write_e57_with_rowindex_and_columnindex_omiting_low_values():
+
+    test_file_path = 'temporary_output_cloud.e57'
+    with pye57.E57(test_file_path, mode='w') as e57:
+        # set some test points with missing row and column 0 (so np.min of it in write_scan_raw is larger than 0)
+        data_raw = {}
+        data_raw["cartesianX"] = np.array([0, 1, 2, 3]).astype(float)
+        data_raw["cartesianY"] = np.array([0, 1, 2, 3]).astype(float)
+        data_raw["cartesianZ"] = np.array([0, 1, 2, 3]).astype(float)
+        data_raw["rowIndex"] = np.array([1, 1, 2, 3]).astype(int)
+        data_raw["columnIndex"] = np.array([1, 1, 2, 3]).astype(int)
+
+        try:
+            # the next line will throw without the suggested fix
+            e57.write_scan_raw(data_raw, name='test_output_with_row_and_column')
+        except pye57.libe57.E57Exception as ex:
+            print(ex)
+            assert False
+    
+    assert os.path.isfile(test_file_path)
+    os.remove(test_file_path)
+    assert not os.path.isfile(test_file_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -429,8 +429,8 @@ def test_write_e57_with_rowindex_and_columnindex_omiting_low_values(temp_e57_wri
         data_raw["cartesianX"] = np.array([0, 1, 2, 3]).astype(float)
         data_raw["cartesianY"] = np.array([0, 1, 2, 3]).astype(float)
         data_raw["cartesianZ"] = np.array([0, 1, 2, 3]).astype(float)
-        data_raw["rowIndex"] = np.array([1, 1, 2, 3]).astype(int)
-        data_raw["columnIndex"] = np.array([1, 1, 2, 3]).astype(int)
+        data_raw["rowIndex"] = np.array([1, 1, 2, 3])
+        data_raw["columnIndex"] = np.array([1, 1, 2, 3])
 
         try:
             # the next line will throw without the suggested fix

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -421,10 +421,9 @@ def test_clone_e57(e57_with_data_and_images_path, temp_e57_write):
     out_image.close()
 
 
-def test_write_e57_with_rowindex_and_columnindex_omiting_low_values():
+def test_write_e57_with_rowindex_and_columnindex_omiting_low_values(temp_e57_write):
 
-    test_file_path = 'temporary_output_cloud.e57'
-    with pye57.E57(test_file_path, mode='w') as e57:
+    with pye57.E57(temp_e57_write, mode='w') as e57:
         # set some test points with missing row and column 0 (so np.min of it in write_scan_raw is larger than 0)
         data_raw = {}
         data_raw["cartesianX"] = np.array([0, 1, 2, 3]).astype(float)
@@ -440,6 +439,4 @@ def test_write_e57_with_rowindex_and_columnindex_omiting_low_values():
             print(ex)
             assert False
     
-    assert os.path.isfile(test_file_path)
-    os.remove(test_file_path)
-    assert not os.path.isfile(test_file_path)
+    assert os.path.isfile(temp_e57_write)


### PR DESCRIPTION
The detailed issue description can be found here: https://github.com/davidcaron/pye57/issues/80

In essence: a C++ E57Exception ErrorValueOfBounds bubbled through, if written values in "rowIndex" or "columnIndex" inside write_scan_raw were all greater than zero. I had this use case, because of filtering clouds. This PR should fix the issue. Without the fix in e57.py, you can reproduce the bug with the suggested test failing. Fell free to ask for support on this. I am available. Thanks!