### PR TITLE
Added more infos to C++ exception reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,12 +90,14 @@ class BuildExt(build_ext):
             opts.append("-DCRCPP_USE_CPP11")
             opts.append("-DCRCPP_BRANCHLESS")
             opts.append("-Wno-unused-variable")
+            opts.append("-DE57_ENABLE_DIAGNOSTIC_OUTPUT")
         elif ct == "msvc":
             opts.append(f'/DVERSION_INFO="{version}"')
             opts.append(rf'/DREVISION_ID="\"{revision_id}\""')
             opts.append("/DCRCPP_USE_CPP11")
             opts.append("/DCRCPP_BRANCHLESS")
             opts.append("/DWINDOWS")
+            opts.append("/DE57_ENABLE_DIAGNOSTIC_OUTPUT")
         for ext in self.extensions:
             ext.extra_compile_args = opts
 

--- a/src/pye57/libe57_wrapper.cpp
+++ b/src/pye57/libe57_wrapper.cpp
@@ -7,6 +7,8 @@
 #include <E57Format.h>
 #include <E57Version.h>
 #include <ASTMVersion.h>
+#include <sstream>
+#include <string.h>
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -40,11 +42,14 @@ PYBIND11_MODULE(libe57, m) {
 
     static py::exception<E57Exception> exc(m, "E57Exception");
     py::register_exception_translator([](std::exception_ptr p) {
-    try {
-        if (p) std::rethrow_exception(p);
-    } catch (const E57Exception &e) {
-        exc(Utilities::errorCodeToString(e.errorCode()).c_str());
-    }
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const E57Exception &e) {
+            std::stringstream ss;
+            e.report(__FILE__, __LINE__, __FUNCTION__, ss);
+            std::string output = e.errorStr() + std::string("\n\n") + ss.str();
+            exc(output.c_str());
+        }
     });
 
     m.attr("E57_FORMAT_MAJOR") = E57_FORMAT_MAJOR;


### PR DESCRIPTION
Hi!

I just tested this and I must say, this would have saved me a lot of time with my previous bugfix. :-) The C++ exception looks much better now: 
![grafik](https://github.com/user-attachments/assets/77a30ca2-22c5-4d49-93d9-8e448684eccf)
I commented-out my last fix to trigger an exception on purpose in test-runs for this. Especially the context info helps a lot. What do you think?

Best regards,
                     Christian