### PR TITLE
feat: export COORDINATE_SYSTEMS

### DIFF
--- a/src/pye57/__init__.py
+++ b/src/pye57/__init__.py
@@ -1,3 +1,3 @@
 from pye57 import libe57
 from pye57.scan_header import ScanHeader
-from pye57.e57 import E57
+from pye57.e57 import E57, COORDINATE_SYSTEMS


### PR DESCRIPTION
What it fixes:
get_coordinate_system() in scan_header.py has COORDINATE_SYSTEMS as an argument, making it unusable outside the library.

Motivation:
I need to know in which coordinate system the E57 file data is.

Solution:
Add COORDINATE_SYSTEMS in _init_.py.

Note:
Another solution would be to import COORDINATE_SYSTEMS in scan_header.py and remove it from the get_coordinate_system() argument list, but I didn't look deeply into the repercussions of that.