### PR TITLE
Bump libE57Format submodule from v3.1.1 to v3.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,14 @@ jobs:
   build-and-test-windows:
     name: Windows (python ${{ matrix.python-version }})
     runs-on: windows-2022
+    # `pwsh -l` is a login shell, which runs the profile that
+    # `conda-incubator/setup-miniconda` installs to auto-activate the `pye57`
+    # env. Without `-l`, conda activation is skipped and `python`/`pip` resolve
+    # to the hosted-tool Python instead of conda's, so xerces-c headers from
+    # `<conda>/Library/include` never reach cl.exe.
+    defaults:
+      run:
+        shell: pwsh -l {0}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -57,23 +65,23 @@ jobs:
           miniconda-version: "latest"
 
       - name: Install Dependencies
-        shell: pwsh
         run: |
           conda install -y xerces-c
+          pip install numpy pybind11 setuptools wheel pyquaternion
 
       - name: Configure MSVC console
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install package
-        shell: pwsh
-        run: pip install .
+        # `--no-build-isolation` keeps the build inside the conda env so
+        # `sys.executable` (used by setup.py to locate `<conda>/Library`)
+        # points at conda's python, not pip's overlay venv.
+        run: pip install . --no-build-isolation -v
 
       - name: Install pytest
-        shell: pwsh
         run: pip install pytest
 
       - name: Run tests
-        shell: pwsh
         run: python -m pytest tests
 
   build-and-test-macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,10 @@ jobs:
   build-and-test-windows:
     name: Windows (python ${{ matrix.python-version }})
     runs-on: windows-2022
-    # `pwsh -l` is a login shell, which runs the profile that
-    # `conda-incubator/setup-miniconda` installs to auto-activate the `pye57`
-    # env. Without `-l`, conda activation is skipped and `python`/`pip` resolve
-    # to the hosted-tool Python instead of conda's, so xerces-c headers from
-    # `<conda>/Library/include` never reach cl.exe.
+    # `pwsh -l` runs the profile installed by `conda-incubator/setup-miniconda`,
+    # which makes `python` resolve to the conda env. But `pip` still resolves to
+    # the hosted-tool Python on PATH, so all install commands use `python -m pip`
+    # to keep pip and python on the same interpreter.
     defaults:
       run:
         shell: pwsh -l {0}
@@ -67,7 +66,7 @@ jobs:
       - name: Install Dependencies
         run: |
           conda install -y xerces-c
-          pip install numpy pybind11 setuptools wheel pyquaternion
+          python -m pip install numpy pybind11 setuptools wheel
 
       - name: Configure MSVC console
         uses: ilammy/msvc-dev-cmd@v1
@@ -76,10 +75,10 @@ jobs:
         # `--no-build-isolation` keeps the build inside the conda env so
         # `sys.executable` (used by setup.py to locate `<conda>/Library`)
         # points at conda's python, not pip's overlay venv.
-        run: pip install . --no-build-isolation -v
+        run: python -m pip install . --no-build-isolation -v
 
       - name: Install pytest
-        run: pip install pytest
+        run: python -m pip install pytest
 
       - name: Run tests
         run: python -m pytest tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          conda install -y xerces-c
+          conda install -y xerces-c pip
           python -m pip install numpy pybind11 setuptools wheel
 
       - name: Configure MSVC console

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,14 @@ extra_link_args = []
 if platform.system() == "Windows":
     libraries.append("xerces-c_3")
 
-    # using conda
-    conda_library_dir = Path(sys.executable).parent / "Library"
+    # using conda — prefer CONDA_PREFIX since `pip install .` without
+    # `--no-build-isolation` puts sys.executable in pip's overlay venv,
+    # not the conda env that actually has xerces-c installed.
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        conda_library_dir = Path(conda_prefix) / "Library"
+    else:
+        conda_library_dir = Path(sys.executable).parent / "Library"
     if conda_library_dir.exists():
         library_dirs.append(str(conda_library_dir / "lib"))
         include_dirs.append(str(conda_library_dir / "include"))


### PR DESCRIPTION
Brings in upstream CMake and standards-conformance improvements from libE57Format v3.2.0 and v3.3.0.

Verified on Windows + conda-forge xerces-c + MSVC 2022, Python 3.13:
- pip install . builds cleanly (only deprecation warnings for old E57_ERROR_*/CHECKSUM_POLICY_* enum names used in libe57_wrapper.cpp, which are still available in 3.3.0 and slated for removal in 4.0).
- All 26 tests in tests/test_main.py pass.
- Smoke test reads tests/test_data/*.e57 (cartesian + spherical) without regression.